### PR TITLE
Hotfix Frontend 3.12 auth. Matei

### DIFF
--- a/frontend-csu/src/components/componentsUI/PlayerSummary.css
+++ b/frontend-csu/src/components/componentsUI/PlayerSummary.css
@@ -31,6 +31,7 @@
 .player-summary__divider {
    color: var(--post_date_color);
    font-weight: bold;
+   margin-bottom: 0;
 }
 
 .player-summary__name {


### PR DESCRIPTION
S-a reparat bug-ul prin care elementele de tip `paragraph` din player summary erau suprascrise de CSS-ul din pagina de `AboutUs`.